### PR TITLE
[FIX]queue.job: remove the overwrite of the write function.

### DIFF
--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -167,12 +167,6 @@ class QueueJob(models.Model):
             if msg:
                 record.message_post(body=msg, subtype="queue_job.mt_job_failed")
 
-    def write(self, vals):
-        res = super(QueueJob, self).write(vals)
-        if vals.get("state") == "failed":
-            self._message_post_on_failure()
-        return res
-
     def _subscribe_users_domain(self):
         """Subscribe all users having the 'Queue Job Manager' group"""
         group = self.env.ref("queue_job.group_queue_job_manager")


### PR DESCRIPTION
We've already removed the mail thread from the job queue for optimization, means we cannot use any mail.tread method.